### PR TITLE
memory_info 可能是None导致报错了启动失败

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -52,7 +52,10 @@ class AppBuffer(BrowserBuffer):
 
         for proc in psutil.process_iter(['cpu_percent', 'memory_info', 'pid', 'name', 'username', 'cmdline']):
             info = proc.info
-            memory_number = info["memory_info"].rss
+            memory_info = info["memory_info"]
+            if memory_info is None:
+                continue
+            memory_number = memory_info.rss
             info["memory_number"] = memory_number
             info["memory"] = self.format_memory(memory_number)
             info["cmdline"] = " ".join(info["cmdline"])


### PR DESCRIPTION
➜  eaf-system-monitor git:(master) python
Python 3.10.4 (main, Jun 16 2022, 17:51:03) [Clang 13.0.0 (clang-1300.0.27.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import psutil
>>> for proc in psutil.process_iter(['memory_info']):
...     info = proc.info
...     memory_number = info["memory_info"]
...     print(memory_number)
...
None
None
None
None
None