### PR TITLE
Fix bug: info["cmdline"] could be None and cannot join

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -65,7 +65,7 @@ class AppBuffer(BrowserBuffer):
             memory_number = memory_info.rss
             info["memory_number"] = memory_number
             info["memory"] = self.format_memory(memory_number)
-            info["cmdline"] = " ".join(info["cmdline"])
+            info["cmdline"] = " ".join(info["cmdline"]) if info["cmdline"] is not None else ""
             infos.append(proc.info)
 
         infos.sort(key=cmp_to_key(self.process_compare), reverse=True)


### PR DESCRIPTION
Some times I can open the monitor window but it is blank. And the \*eaf\* buffer pop the information below every second:

```
Traceback (most recent call last):
  File "/home/thattemperature/.emacs.d/site-lisp/emacs-application-framework/core/utils.py", line 56, in on_signal_received
    self._func(obj, *args, **kwargs)
  File "/home/thattemperature/.emacs.d/site-lisp/emacs-application-framework/app/system-monitor/buffer.py", line 68, in update_process_info
    info["cmdline"] = " ".join(info["cmdline"])
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can only join an iterable
```

I use try-block and find that info["cmdline"] could be None.